### PR TITLE
:ambulance: hide side nav :before on desktop

### DIFF
--- a/app/styles/_app-nav-primary.scss
+++ b/app/styles/_app-nav-primary.scss
@@ -71,5 +71,8 @@
   .app-nav-primary__mobile-nav-toggle {
     display: none;
   }
+  .app-nav-primary__wrapper::before  {
+    display: none;
+  }
 }
 


### PR DESCRIPTION
The semi-transparent overlay is only for mobile.