### PR TITLE
Fix sidenav click elsewhere issue, loc, desktop visibility

### DIFF
--- a/app/components/app-header.hbs
+++ b/app/components/app-header.hbs
@@ -2,7 +2,7 @@
   <button
     type="button"
     class="app-header__mobile-nav-toggle"
-    aria-label="Show Site Navigation"
+    aria-label={{t 'navigation.open'}}
     {{on "click" @openNavPrimary}}>
     <svg role="image" aria-hidden="true" preserveAspectRatio="xMidYMid meet" height="1em" width="1em" fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke="currentColor">
       <g>

--- a/app/components/app-nav-primary.hbs
+++ b/app/components/app-nav-primary.hbs
@@ -3,15 +3,16 @@
     {{focus-trap
       isActive=(media 'isMobile')
       focusTrapOptions=(hash
-        onDeactivate=(action @close)
+        onDeactivate=(fn @close)
       )
     }}>
     <nav
-      class="app-nav-primary {{if @navPrimaryIsOpen 'app-nav-primary--open'}}"
+      class="app-nav-primary {{if this.show 'app-nav-primary--open'}}"
       {{click-elsewhere @close isEnabled=this.show}}>
       <button
+        type="button"
         class="app-nav-primary__mobile-nav-toggle"
-        aria-label="Hide Site Navigation"
+        aria-label={{t 'navigation.close'}}
         {{on "click" @close}}>
         <svg role="image" aria-hidden="true" preserveAspectRatio="xMidYMid meet" height="1em" width="1em" fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke="currentColor">
           <g>
@@ -25,7 +26,7 @@
       <em>TODO: Make into real links...</em>
 
       <ul class="app-nav-primary__list">
-        {{#unless isLoading}}
+        {{#unless this.isLoading}}
           {{#each this.contents as | content |}}
             <li> {{!-- Convert to LinkTo's when we have content page routing done --}}
               {{content.title}}

--- a/app/modifiers/click-elsewhere.js
+++ b/app/modifiers/click-elsewhere.js
@@ -10,6 +10,8 @@ export default modifier((element, [callback], options = { isEnabled: true }) => 
   }, 0); // Wait for the next Javascript Run Loop
 
   return () => {
-    document.removeEventListener('click', handleClick);
+    setTimeout(() => {
+      document.removeEventListener('click', handleClick);
+    }, 0); // Wait for the next Javascript Run Loop
   };
 });

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1,5 +1,8 @@
 site_name: Ember Component Patterns
 site_name_technical: ember-component-patterns
+navigation:
+  open: Show Site Navigation 
+  close: Hide Site Navigation 
 footer:
   link_repo: GitHub Repository
 index:


### PR DESCRIPTION
Fixes a number of issues found after merging in the side nav.

1. Fixes a race condition creating and removing click handlers in the click-elsewhere modifier that resulted in the menu appearing to not open after changing browser size between mobile/desktop sizes
2. Fixed missed localization aria labels
3. Fixed visibility of side navigation on desktop